### PR TITLE
Criar rota de login de usuário com JWT

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/backend/.mvn/wrapper/maven-wrapper.properties
+++ b/backend/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/backend/mvnw
+++ b/backend/mvnw
@@ -1,0 +1,259 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/backend/mvnw.cmd
+++ b/backend/mvnw.cmd
@@ -1,0 +1,149 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.3.4</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.api</groupId>
+	<artifactId>app</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>app</name>
+	<description>Demo project for Spring Boot</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.9.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
+
+
+
+
+
+
+	</dependencies>
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -71,6 +71,11 @@
 			<artifactId>jaxb-api</artifactId>
 			<version>2.3.1</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.1.0</version>
+		</dependency>
 
 
 

--- a/backend/src/main/java/com/api/app/AppApplication.java
+++ b/backend/src/main/java/com/api/app/AppApplication.java
@@ -1,0 +1,13 @@
+package com.api.app;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AppApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(AppApplication.class, args);
+	}
+
+}

--- a/backend/src/main/java/com/api/app/controllers/UsuarioController.java
+++ b/backend/src/main/java/com/api/app/controllers/UsuarioController.java
@@ -1,0 +1,92 @@
+package com.api.app.controllers;
+
+import com.api.app.dtos.LoginRequest;
+import com.api.app.dtos.LoginResponse;
+import com.api.app.models.TipoAcesso;
+import com.api.app.models.UsuarioModel;
+import com.api.app.repositories.UsuarioRepository;
+import com.api.app.services.UsuarioService;  // Importando o UsuarioService
+
+import com.api.app.security.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/usuario")
+public class UsuarioController {
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private UsuarioService usuarioService;  // Injetando o UsuarioService
+
+    @PostMapping("/login")
+    public LoginResponse login(@RequestBody LoginRequest login) {
+        Optional<UsuarioModel> user = usuarioRepository.findByEmail(login.getEmail());
+        if (user.isPresent() && user.get().getSenha().equals(login.getSenha())) {
+            // Passando o tipo (papel) como "INQUILINO" ou o papel que o usuário tem
+            String token = jwtUtil.generateToken(user.get().getEmail(), user.get().getTipoAcesso().name());
+            return new LoginResponse(token);
+        }
+        throw new RuntimeException("Credenciais inválidas");
+    }
+
+    @PostMapping("/cadastrar")
+    public UsuarioModel criarUsuario(@RequestBody UsuarioModel usuario) {
+        usuario.setAtivo(true);  // Define como ativo o usuário criado
+        usuario.setTipoAcesso(TipoAcesso.PROPRIETARIO);  // Aqui, ao invés de usar uma String, usamos o enum TipoAcesso
+        return usuarioRepository.save(usuario);
+    }
+
+    @GetMapping("/listar")
+    public ResponseEntity<List<UsuarioModel>> listarUsuarios() {
+        List<UsuarioModel> usuarios = usuarioService.listarTodos();  // Usando o método do service
+        return ResponseEntity.ok(usuarios);
+    }
+
+    @DeleteMapping("/deletar/{id}")
+    public ResponseEntity<String> deletarUsuario(@PathVariable Long id) {
+        usuarioService.deletarUsuario(id);  // Usando o método do service
+        return ResponseEntity.ok("Usuário deletado com sucesso!");
+    }
+
+    @PutMapping("/alterar/{id}")
+    public ResponseEntity<UsuarioModel> alterarUsuario(@PathVariable Long id, @RequestBody UsuarioModel usuarioAtualizado, @RequestHeader("Authorization") String token) {
+        // Valida o token antes de realizar a operação
+        String username = jwtUtil.extractUsername(token.substring(7));  // Remove o "Bearer " do token
+
+        if (username == null) {
+            throw new RuntimeException("Token inválido ou expirado");
+        }
+
+        // Verifica se o usuário autenticado pode editar esse cadastro
+        Optional<UsuarioModel> usuarioExistente = usuarioRepository.findById(id);
+        if (usuarioExistente.isPresent()) {
+            UsuarioModel usuario = usuarioExistente.get();
+            if (!usuario.getEmail().equals(username)) {
+                throw new RuntimeException("Você não tem permissão para editar este usuário!");
+            }
+
+            // Atualiza os dados do usuário
+            usuario.setEmail(usuarioAtualizado.getEmail());
+            usuario.setSenha(usuarioAtualizado.getSenha());
+            usuario.setAtivo(usuarioAtualizado.getAtivo());
+            usuario.setTipoAcesso(usuarioAtualizado.getTipoAcesso());
+            usuario.setObservacao(usuarioAtualizado.getObservacao());
+
+            // Salva as alterações
+            usuarioRepository.save(usuario);
+            return ResponseEntity.ok(usuario);
+        } else {
+            throw new RuntimeException("Usuário não encontrado!");
+        }
+    }
+}

--- a/backend/src/main/java/com/api/app/controllers/UsuarioController.java
+++ b/backend/src/main/java/com/api/app/controllers/UsuarioController.java
@@ -5,10 +5,10 @@ import com.api.app.dtos.LoginResponse;
 import com.api.app.models.TipoAcesso;
 import com.api.app.models.UsuarioModel;
 import com.api.app.repositories.UsuarioRepository;
-import com.api.app.services.UsuarioService;  // Importando o UsuarioService
-
+import com.api.app.services.UsuarioService;
 import com.api.app.security.JwtUtil;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,13 +26,13 @@ public class UsuarioController {
     private JwtUtil jwtUtil;
 
     @Autowired
-    private UsuarioService usuarioService;  // Injetando o UsuarioService
+    private UsuarioService usuarioService;
 
     @PostMapping("/login")
     public LoginResponse login(@RequestBody LoginRequest login) {
         Optional<UsuarioModel> user = usuarioRepository.findByEmail(login.getEmail());
         if (user.isPresent() && user.get().getSenha().equals(login.getSenha())) {
-            // Passando o tipo (papel) como "INQUILINO" ou o papel que o usuário tem
+            // Gera o token com base no email e no tipo de acesso (role)
             String token = jwtUtil.generateToken(user.get().getEmail(), user.get().getTipoAcesso().name());
             return new LoginResponse(token);
         }
@@ -40,53 +40,99 @@ public class UsuarioController {
     }
 
     @PostMapping("/cadastrar")
-    public UsuarioModel criarUsuario(@RequestBody UsuarioModel usuario) {
-        usuario.setAtivo(true);  // Define como ativo o usuário criado
-        usuario.setTipoAcesso(TipoAcesso.PROPRIETARIO);  // Aqui, ao invés de usar uma String, usamos o enum TipoAcesso
-        return usuarioRepository.save(usuario);
+    public ResponseEntity<?> criarUsuario(@RequestBody UsuarioModel usuario) {
+        Optional<UsuarioModel> existingUser = usuarioRepository.findByEmail(usuario.getEmail());
+        if(existingUser.isPresent()){
+            return ResponseEntity.badRequest().body("Email já cadastrado.");
+        }
+        usuario.setAtivo(true);
+        if (usuario.getTipoAcesso() == null) {
+            usuario.setTipoAcesso(TipoAcesso.PROPRIETARIO);
+        }
+        UsuarioModel savedUser = usuarioRepository.save(usuario);
+        return ResponseEntity.ok(savedUser);
     }
 
     @GetMapping("/listar")
     public ResponseEntity<List<UsuarioModel>> listarUsuarios() {
-        List<UsuarioModel> usuarios = usuarioService.listarTodos();  // Usando o método do service
+        List<UsuarioModel> usuarios = usuarioService.listarTodos();
         return ResponseEntity.ok(usuarios);
     }
 
     @DeleteMapping("/deletar/{id}")
     public ResponseEntity<String> deletarUsuario(@PathVariable Long id) {
-        usuarioService.deletarUsuario(id);  // Usando o método do service
+        usuarioService.deletarUsuario(id);
         return ResponseEntity.ok("Usuário deletado com sucesso!");
     }
 
     @PutMapping("/alterar/{id}")
-    public ResponseEntity<UsuarioModel> alterarUsuario(@PathVariable Long id, @RequestBody UsuarioModel usuarioAtualizado, @RequestHeader("Authorization") String token) {
-        // Valida o token antes de realizar a operação
-        String username = jwtUtil.extractUsername(token.substring(7));  // Remove o "Bearer " do token
+    public ResponseEntity<Object> alterarUsuario(
+            @PathVariable Long id,
+            @RequestBody UsuarioModel usuarioAtualizado,
+            @RequestHeader("Authorization") String tokenHeader) {
 
-        if (username == null) {
-            throw new RuntimeException("Token inválido ou expirado");
+        // Log inicial para depuração
+        System.out.println("=== Entrou no endpoint /usuario/alterar/" + id + " ===");
+        System.out.println("Body recebido: " + usuarioAtualizado);
+
+        // Extrai o token removendo o prefixo "Bearer " se presente
+        String token = tokenHeader.startsWith("Bearer ") ? tokenHeader.substring(7) : tokenHeader;
+        System.out.println("Token extraído: " + token);
+
+        if (!jwtUtil.validateToken(token)) {
+            System.out.println("Token inválido ou expirado.");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body("Token inválido ou expirado");
         }
 
-        // Verifica se o usuário autenticado pode editar esse cadastro
-        Optional<UsuarioModel> usuarioExistente = usuarioRepository.findById(id);
-        if (usuarioExistente.isPresent()) {
-            UsuarioModel usuario = usuarioExistente.get();
-            if (!usuario.getEmail().equals(username)) {
-                throw new RuntimeException("Você não tem permissão para editar este usuário!");
-            }
+        // Extrai o email e o role do token
+        String emailFromToken = jwtUtil.extractUsername(token);
+        String roleFromToken = jwtUtil.extractRole(token);
+        System.out.println("RoleFromToken = " + roleFromToken + ", EmailFromToken = " + emailFromToken);
 
-            // Atualiza os dados do usuário
-            usuario.setEmail(usuarioAtualizado.getEmail());
-            usuario.setSenha(usuarioAtualizado.getSenha());
-            usuario.setAtivo(usuarioAtualizado.getAtivo());
-            usuario.setTipoAcesso(usuarioAtualizado.getTipoAcesso());
-            usuario.setObservacao(usuarioAtualizado.getObservacao());
-
-            // Salva as alterações
-            usuarioRepository.save(usuario);
-            return ResponseEntity.ok(usuario);
-        } else {
-            throw new RuntimeException("Usuário não encontrado!");
+        // Busca o usuário a ser alterado
+        Optional<UsuarioModel> usuarioOpt = usuarioRepository.findById(id);
+        if (!usuarioOpt.isPresent()) {
+            System.out.println("Usuário com id " + id + " não encontrado.");
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body("Usuário não encontrado!");
         }
+        UsuarioModel usuario = usuarioOpt.get();
+        System.out.println("Usuário encontrado: " + usuario);
+
+        // Se o usuário logado for INQUILINO, só pode alterar seu próprio cadastro.
+        // Se for PROPRIETARIO, permite editar qualquer usuário, sem verificar o email.
+        if ("ROLE_INQUILINO".equals(roleFromToken) && !usuario.getEmail().equals(emailFromToken)) {
+            System.out.println("Bloqueado: Inquilino tentando editar outro usuário. Email do cadastro: "
+                    + usuario.getEmail());
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body("Inquilino não tem permissão para editar outro usuário!");
+        }
+
+        System.out.println("Verificações de permissão concluídas. Prosseguindo com a alteração.");
+
+        // Atualiza os dados do usuário
+        usuario.setEmail(usuarioAtualizado.getEmail());
+        usuario.setSenha(usuarioAtualizado.getSenha());
+        usuario.setAtivo(usuarioAtualizado.getAtivo());
+        usuario.setTipoAcesso(usuarioAtualizado.getTipoAcesso());
+        usuario.setObservacao(usuarioAtualizado.getObservacao());
+        System.out.println("Dados atualizados: " + usuario);
+
+        usuarioRepository.save(usuario);
+        System.out.println("Usuário salvo com sucesso.");
+
+        return ResponseEntity.ok(usuario);
     }
+
+
+
+
+
+
+
+
+
+
+
 }

--- a/backend/src/main/java/com/api/app/dtos/LoginRequest.java
+++ b/backend/src/main/java/com/api/app/dtos/LoginRequest.java
@@ -1,0 +1,10 @@
+
+package com.api.app.dtos;
+
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+    private String email;
+    private String senha;
+}

--- a/backend/src/main/java/com/api/app/dtos/LoginResponse.java
+++ b/backend/src/main/java/com/api/app/dtos/LoginResponse.java
@@ -1,0 +1,11 @@
+
+package com.api.app.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class LoginResponse {
+    private String token;
+}

--- a/backend/src/main/java/com/api/app/models/InquilinoModel.java
+++ b/backend/src/main/java/com/api/app/models/InquilinoModel.java
@@ -1,0 +1,24 @@
+package com.api.app.models;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Table(name = "inquilino")  // Se quiser personalizar o nome da tabela
+@Data
+public class InquilinoModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private  String email;
+    private String cpf;
+    private String telefone;
+
+    // Outros atributos específicos de inquilino
+
+    @OneToOne
+    @JoinColumn(name = "usuario_id")
+    private UsuarioModel usuario;
+}

--- a/backend/src/main/java/com/api/app/models/ProprietarioModel.java
+++ b/backend/src/main/java/com/api/app/models/ProprietarioModel.java
@@ -1,0 +1,23 @@
+package com.api.app.models;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Table(name = "proprietario") // Se quiser personalizar o nome da tabela
+@Data
+public class ProprietarioModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private  String email;
+    private String cnpj;
+    private String razaoSocial;
+    // Outros atributos específicos de proprietário
+
+    @OneToOne
+    @JoinColumn(name = "usuario_id")
+    private UsuarioModel usuario;
+}

--- a/backend/src/main/java/com/api/app/models/TipoAcesso.java
+++ b/backend/src/main/java/com/api/app/models/TipoAcesso.java
@@ -1,0 +1,6 @@
+package com.api.app.models;
+
+public enum TipoAcesso {
+    PROPRIETARIO,
+    INQUILINO
+}

--- a/backend/src/main/java/com/api/app/models/UsuarioModel.java
+++ b/backend/src/main/java/com/api/app/models/UsuarioModel.java
@@ -14,10 +14,17 @@ public class UsuarioModel {
 
     private String email;
     private String senha;
-    private Boolean ativo; // Considerando que "ativo" controlará o status do usuário
+    private Boolean ativo; // Indica se o usuário está ativo
     private String observacao;
 
     @Enumerated(EnumType.STRING)
-    private TipoAcesso tipoAcesso;  // Renomeando para 'TipoAcesso' seguindo convenção Java
+    private TipoAcesso tipoAcesso;  // Enum com valores, por exemplo, PROPRIETARIO e INQUILINO
 
+    // Relacionamento OneToOne com o perfil Inquilino
+    @OneToOne(mappedBy = "usuario", cascade = CascadeType.ALL)
+    private InquilinoModel inquilino;
+
+    // Relacionamento OneToOne com o perfil Proprietário
+    @OneToOne(mappedBy = "usuario", cascade = CascadeType.ALL)
+    private ProprietarioModel proprietario;
 }

--- a/backend/src/main/java/com/api/app/models/UsuarioModel.java
+++ b/backend/src/main/java/com/api/app/models/UsuarioModel.java
@@ -1,0 +1,23 @@
+package com.api.app.models;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Table(name = "usuario")
+@Data
+public class UsuarioModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+    private String senha;
+    private Boolean ativo; // Considerando que "ativo" controlará o status do usuário
+    private String observacao;
+
+    @Enumerated(EnumType.STRING)
+    private TipoAcesso tipoAcesso;  // Renomeando para 'TipoAcesso' seguindo convenção Java
+
+}

--- a/backend/src/main/java/com/api/app/repositories/InquilinoRepository.java
+++ b/backend/src/main/java/com/api/app/repositories/InquilinoRepository.java
@@ -1,0 +1,9 @@
+package com.api.app.repositories;
+
+import com.api.app.models.InquilinoModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface InquilinoRepository extends JpaRepository<InquilinoModel, Long> {
+    Optional<InquilinoModel> findByEmail(String email);
+}

--- a/backend/src/main/java/com/api/app/repositories/UsuarioRepository.java
+++ b/backend/src/main/java/com/api/app/repositories/UsuarioRepository.java
@@ -1,0 +1,10 @@
+package com.api.app.repositories;
+
+import com.api.app.models.UsuarioModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UsuarioRepository extends JpaRepository<UsuarioModel, Long> {
+    Optional<UsuarioModel> findByEmail(String email);
+}

--- a/backend/src/main/java/com/api/app/security/JwtFilter.java
+++ b/backend/src/main/java/com/api/app/security/JwtFilter.java
@@ -1,0 +1,54 @@
+package com.api.app.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // Ignora as rotas públicas (login e cadastro)
+        if (request.getRequestURI().equals("/usuario/login") || request.getRequestURI().equals("/usuario/cadastrar")) {
+            filterChain.doFilter(request, response);  // Permite continuar sem verificar o token
+            return;
+        }
+
+        String token = getTokenFromRequest(request);  // Obtém o token da requisição
+
+        if (token != null && jwtUtil.validateToken(token, "proprietario")) {  // Valida o token
+            String role = jwtUtil.extractRole(token);  // Extrai o papel do token
+
+            if ("proprietario".equals(role)) {  // Verifica se o papel é 'proprietario'
+                filterChain.doFilter(request, response);  // Permite o acesso
+            } else {
+                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                response.getWriter().write("Acesso negado: Não é um proprietário");
+            }
+        } else {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Token inválido ou não fornecido");
+        }
+    }
+
+    // Método para extrair o token da requisição
+    private String getTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);  // Remove "Bearer " do começo do token
+        }
+        return null;
+    }
+}
+

--- a/backend/src/main/java/com/api/app/security/JwtUtil.java
+++ b/backend/src/main/java/com/api/app/security/JwtUtil.java
@@ -1,0 +1,78 @@
+package com.api.app.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Component
+public class JwtUtil {
+
+    private final String SECRET_KEY = "segredo_super_secreto"; // Você pode pegar do application.properties se preferir
+
+    // Método para extrair o nome de usuário do token
+    public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    // Método para extrair o papel (tipo_acesso) do token
+    public String extractRole(String token) {
+        return extractClaim(token, claims -> claims.get("role", String.class)); // Assuming role is stored in 'role' claim
+    }
+
+    // Método para extrair a data de expiração do token
+    public Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
+    }
+
+    // Método genérico para extrair qualquer dado do token
+    public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    // Método para extrair todos os dados (claims) do token
+    private Claims extractAllClaims(String token) {
+        return Jwts.parser()
+                .setSigningKey(SECRET_KEY)
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    // Método para verificar se o token já expirou
+    public Boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    // Método para gerar o token JWT
+    public String generateToken(String username, String role) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("role", "ROLE_" + role);  // Aqui você adiciona o tipo de acesso/role ao token
+        claims.put("email", username);  // Adicionando o e-mail ao token para identificação
+
+        return createToken(claims, username);
+    }
+
+
+    // Método privado para criar o token JWT com claims e dados de expiração
+    private String createToken(Map<String, Object> claims, String subject) {
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(subject)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 10)) // 10 horas
+                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .compact();
+    }
+    // Método para validar o token
+    public Boolean validateToken(String token, String username) {
+        final String extractedUsername = extractUsername(token);
+        final String extractedRole = extractRole(token);
+        return (extractedUsername.equals(username) && !isTokenExpired(token));
+    }
+}

--- a/backend/src/main/java/com/api/app/security/JwtUtil.java
+++ b/backend/src/main/java/com/api/app/security/JwtUtil.java
@@ -15,28 +15,28 @@ public class JwtUtil {
 
     private final String SECRET_KEY = "segredo_super_secreto"; // Você pode pegar do application.properties se preferir
 
-    // Método para extrair o nome de usuário do token
+    // Extrai o nome de usuário (subject) do token
     public String extractUsername(String token) {
         return extractClaim(token, Claims::getSubject);
     }
 
-    // Método para extrair o papel (tipo_acesso) do token
+    // Extrai o papel (tipo_acesso) do token
     public String extractRole(String token) {
-        return extractClaim(token, claims -> claims.get("role", String.class)); // Assuming role is stored in 'role' claim
+        return extractClaim(token, claims -> claims.get("role", String.class));
     }
 
-    // Método para extrair a data de expiração do token
+    // Extrai a data de expiração do token
     public Date extractExpiration(String token) {
         return extractClaim(token, Claims::getExpiration);
     }
 
-    // Método genérico para extrair qualquer dado do token
+    // Método genérico para extrair qualquer claim do token
     public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
         final Claims claims = extractAllClaims(token);
         return claimsResolver.apply(claims);
     }
 
-    // Método para extrair todos os dados (claims) do token
+    // Extrai todos os claims do token
     private Claims extractAllClaims(String token) {
         return Jwts.parser()
                 .setSigningKey(SECRET_KEY)
@@ -44,35 +44,37 @@ public class JwtUtil {
                 .getBody();
     }
 
-    // Método para verificar se o token já expirou
+    // Verifica se o token já expirou
     public Boolean isTokenExpired(String token) {
         return extractExpiration(token).before(new Date());
     }
 
-    // Método para gerar o token JWT
+    // Gera o token JWT, adicionando claims para role e email
     public String generateToken(String username, String role) {
         Map<String, Object> claims = new HashMap<>();
-        claims.put("role", "ROLE_" + role);  // Aqui você adiciona o tipo de acesso/role ao token
-        claims.put("email", username);  // Adicionando o e-mail ao token para identificação
-
+        claims.put("role", "ROLE_" + role);
+        claims.put("email", username);
         return createToken(claims, username);
     }
 
-
-    // Método privado para criar o token JWT com claims e dados de expiração
+    // Cria o token JWT com claims e tempo de expiração definido (10 horas)
     private String createToken(Map<String, Object> claims, String subject) {
         return Jwts.builder()
                 .setClaims(claims)
                 .setSubject(subject)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 10)) // 10 horas
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 10))
                 .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
                 .compact();
     }
-    // Método para validar o token
-    public Boolean validateToken(String token, String username) {
-        final String extractedUsername = extractUsername(token);
-        final String extractedRole = extractRole(token);
-        return (extractedUsername.equals(username) && !isTokenExpired(token));
+
+    // Valida o token apenas verificando se ele não expirou
+    public Boolean validateToken(String token) {
+        return !isTokenExpired(token);
+    }
+
+    // Valida se o token pertence ao usuário informado (comparando o email do token com o fornecido)
+    public Boolean validateUser(String token, String username) {
+        return extractUsername(token).equals(username);
     }
 }

--- a/backend/src/main/java/com/api/app/security/SecurityConfig.java
+++ b/backend/src/main/java/com/api/app/security/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.api.app.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+@Configuration
+public class SecurityConfig {
+
+    @Autowired
+    private JwtFilter jwtFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()  // Desabilita CSRF (não necessário para JWT)
+                .authorizeHttpRequests()  // Usando o método correto para versões 6.x
+                .requestMatchers("/usuario/cadastrar", "/usuario/login").permitAll()  // Permite acesso sem autenticação para cadastrar e login
+                .requestMatchers("/api/proprietario/**").hasRole("PROPRIETARIO")   // Restringe para o Proprietário
+                .requestMatchers("/api/inquilino/**").hasRole("INQUILINO")         // Restringe para o Inquilino
+                .anyRequest().authenticated()  // Exige autenticação para outras rotas
+                .and()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);  // Sem sessões (usando JWT)
+
+        // Adiciona o filtro JWT antes do filtro de autenticação padrão
+        http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}
+
+

--- a/backend/src/main/java/com/api/app/security/SecurityConfig.java
+++ b/backend/src/main/java/com/api/app/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.api.app.security;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -20,8 +21,12 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf().disable()  // Desabilita CSRF (não necessário para JWT)
                 .authorizeHttpRequests()  // Usando o método correto para versões 6.x
-                .requestMatchers("/usuario/cadastrar", "/usuario/login").permitAll()  // Permite acesso sem autenticação para cadastrar e login
+                .requestMatchers("/usuario/cadastrar", "/usuario/login").permitAll()
+                .requestMatchers(HttpMethod.PUT, "/usuario/alterar/**").hasAnyRole("PROPRIETARIO", "INQUILINO")// Permite acesso sem autenticação para cadastrar e login
                 .requestMatchers("/api/proprietario/**").hasRole("PROPRIETARIO")   // Restringe para o Proprietário
+                .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+
+
                 .requestMatchers("/api/inquilino/**").hasRole("INQUILINO")         // Restringe para o Inquilino
                 .anyRequest().authenticated()  // Exige autenticação para outras rotas
                 .and()

--- a/backend/src/main/java/com/api/app/services/UsuarioService.java
+++ b/backend/src/main/java/com/api/app/services/UsuarioService.java
@@ -1,0 +1,62 @@
+package com.api.app.services;
+
+import com.api.app.models.UsuarioModel;
+import com.api.app.repositories.UsuarioRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class UsuarioService {
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    // Método para autenticar o usuário com o email e senha
+    public Optional<UsuarioModel> autenticar(String email, String senha) {
+        Optional<UsuarioModel> usuario = usuarioRepository.findByEmail(email);
+        if (usuario.isPresent() && usuario.get().getSenha().equals(senha)) {
+            return usuario;
+        }
+        return Optional.empty();
+    }
+
+    // Método para criar um novo usuário
+    public UsuarioModel criarUsuario(UsuarioModel usuario) {
+        return usuarioRepository.save(usuario);
+    }
+
+    // Método para listar todos os usuários
+    public List<UsuarioModel> listarTodos() {
+        return usuarioRepository.findAll();
+    }
+
+    // Método para deletar um usuário pelo ID
+    public void deletarUsuario(Long id) {
+        Optional<UsuarioModel> usuario = usuarioRepository.findById(id);
+        if (usuario.isPresent()) {
+            usuarioRepository.delete(usuario.get());
+        } else {
+            throw new RuntimeException("Usuário não encontrado!");
+        }
+    }
+
+    // Método para alterar um usuário
+    public UsuarioModel alterarUsuario(Long id, UsuarioModel usuarioAtualizado) {
+        Optional<UsuarioModel> usuarioExistente = usuarioRepository.findById(id);
+        if (usuarioExistente.isPresent()) {
+            UsuarioModel usuario = usuarioExistente.get();
+            usuario.setEmail(usuarioAtualizado.getEmail());
+            usuario.setSenha(usuarioAtualizado.getSenha());
+            usuario.setAtivo(usuarioAtualizado.getAtivo());
+            usuario.setTipoAcesso(usuarioAtualizado.getTipoAcesso());
+            usuario.setObservacao(usuarioAtualizado.getObservacao());
+            // Atualize outros campos conforme necessário
+            return usuarioRepository.save(usuario);
+        } else {
+            throw new RuntimeException("Usuário não encontrado!");
+        }
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,0 +1,14 @@
+spring.datasource.url=jdbc:mysql://localhost:3306/mydb_condominio
+spring.datasource.username=root
+spring.datasource.password=root
+
+# Hibernate
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+
+# Encoding
+server.servlet.encoding.charset=UTF-8
+server.servlet.encoding.enabled=true
+server.servlet.encoding.force=true
+jwt.secret=segredo_super_secreto

--- a/backend/src/test/java/com/api/app/AppApplicationTests.java
+++ b/backend/src/test/java/com/api/app/AppApplicationTests.java
@@ -1,0 +1,13 @@
+package com.api.app;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class AppApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
**Por quê**
Para permitir que clientes (inquilinos e proprietários) façam login e obtenham um token JWT, que será usado para proteger e autorizar o acesso às demais rotas da API de forma stateless.

**O que foi feito**  
- Implementada a rota `POST /usuario/login` para gerar token JWT.  
- Implementadas as rotas POST /usuario/cadastrar, GET /usuario/listar, PUT /usuario/alterar/{id} e DELETE /usuario/deletar/{id}
- Integração do Swagger UI (/swagger-ui.html e /v3/api-docs/**) sem necessidade de autenticação
- Adicionada validação de credenciais no controller e no service.  
- Configuração de segurança para permitir acesso público a `/usuario/login` e proteger demais endpoints.  
- Ajustes no `JwtFilter` para popular o `SecurityContext` com as roles extraídas do token.  

